### PR TITLE
Add script for safe git pull

### DIFF
--- a/safe_pull.sh
+++ b/safe_pull.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Script to safely run 'git pull' when untracked files might be overwritten.
+# The file backend/package-lock.json is backed up and removed before pulling.
+
+set -e
+
+FILE="backend/package-lock.json"
+
+# Check if the untracked file exists in the working tree and is not tracked by git
+if [ -f "$FILE" ] && git ls-files --others --exclude-standard | grep -q "$FILE"; then
+    echo "Backing up $FILE before pulling"
+    BACKUP="$FILE.bak.$(date +%Y%m%d%H%M%S)"
+    mv "$FILE" "$BACKUP"
+    echo "Moved $FILE to $BACKUP"
+fi
+
+# Proceed with the pull (uses the branch's configured upstream)
+echo "Running git pull"
+
+git pull


### PR DESCRIPTION
## Summary
- add a helper script `safe_pull.sh` to backup `backend/package-lock.json` and proceed with `git pull`

## Testing
- `bash -n safe_pull.sh`
- `./safe_pull.sh` *(fails: no remote tracking branch)*

------
https://chatgpt.com/codex/tasks/task_e_68544a6196d883238d83f611cc7e6f94